### PR TITLE
fix(DialogBox) : Fix DialogBox error message not getting cleared (#85)

### DIFF
--- a/src/components/workspace/DialogBox.jsx
+++ b/src/components/workspace/DialogBox.jsx
@@ -27,10 +27,12 @@ const DialogBox = props => {
       setInputError(true);
       return;
     }
+    setInputError(false);
     submit(textInput);
   };
 
   const handleCancelButton = () => {
+    setInputError(false);
     close();
   };
 


### PR DESCRIPTION
After showing the error message, the error message was still there for next dialog box render.
This fix will clear the error message if any when dialogbox is closed

closes #85 