### PR TITLE
fix(Workspace) : Fix auto increase of network canvas height (#86)

### DIFF
--- a/src/components/workspace/ToolBar.jsx
+++ b/src/components/workspace/ToolBar.jsx
@@ -19,13 +19,11 @@ import computeDFA from "../../engine/dfa";
 
 const useStyles = makeStyles(theme => ({
   paper: {
-    display: "flex",
-    alignItems: "stretch",
     padding: theme.spacing.unit,
     height: "85vh"
   },
   divUtil: {
-    flex: 1
+    height: "100%"
   },
   icon: {
     margin: theme.spacing.unit,

--- a/src/components/workspace/Workspace.jsx
+++ b/src/components/workspace/Workspace.jsx
@@ -17,15 +17,11 @@ const useStyles = makeStyles(theme => ({
     margin: theme.spacing.unit * 2
   },
   paper: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "stretch",
     padding: theme.spacing.unit,
     height: "85vh"
   },
   canvas: {
-    flex: "1",
-    overFlow: "hidden"
+    height: "calc(100% - 40px - 8px - 4px)"
   }
 }));
 


### PR DESCRIPTION
After closing the dialog box of create node/edge
height of network canvas was automatically increasing by 4px

closes #86 