### PR TITLE
fix(Workspace) : populate edit label textbox when dragged (#92)

### DIFF
--- a/src/components/workspace/Workspace.jsx
+++ b/src/components/workspace/Workspace.jsx
@@ -275,6 +275,20 @@ const Workspace = props => {
     };
   };
 
+  /**
+   * Handles when network is dragged,
+   * triggered once in the start of dragging event
+   *
+   * @param params
+   */
+  const onNetworkDragStart = params => {
+    // edge dragging is not supported
+    const { nodes } = params;
+    if (nodes.length) {
+      onNetworkNodeSelect(params);
+    }
+  };
+
   const OPTIONS = {
     nodes: {
       shape: "circle",
@@ -352,6 +366,10 @@ const Workspace = props => {
 
     automataNetwork.on("deselectEdge", () => {
       onNetworkEdgeDeselect();
+    });
+
+    automataNetwork.on("dragStart", params => {
+      onNetworkDragStart(params);
     });
 
     automataNetwork.on("beforeDrawing", ctx => {


### PR DESCRIPTION
This commit address the issue of edit label not being populated after dragging a node
as while dragging a node, it gets selected. Hence textbox should be updated with the dragged node label.

closes #92 