### PR TITLE
fix(Workspace) : disable edit label textbox when clicked in network canvas (#77)

### DIFF
--- a/src/components/workspace/Workspace.jsx
+++ b/src/components/workspace/Workspace.jsx
@@ -255,6 +255,7 @@ const Workspace = props => {
    * Handles when a node is deselected
    */
   const onNetworkNodeDeselect = () => {
+    disableEditLabelTextBox();
     nodeObject.current = {
       id: "",
       label: "",
@@ -267,6 +268,7 @@ const Workspace = props => {
    * Handles when an edge is deselected
    */
   const onNetworkEdgeDeselect = () => {
+    disableEditLabelTextBox();
     edgeObject.current = {
       id: "",
       from: "",


### PR DESCRIPTION
This commit address the issue of edit label textbox not getting cleared.
When a node is selected, and after that mouse click is done on the empty area of the
network, the node gets deselected however the edit label textbox doesn't get cleared.

closes #77 