### PR TITLE
fix(Workspace) : Remove connected edges when a node is removed (#97)

### DIFF
--- a/src/components/workspace/Workspace.jsx
+++ b/src/components/workspace/Workspace.jsx
@@ -207,14 +207,30 @@ const Workspace = props => {
         notification("error", "cannot delete start node");
         return;
       }
+      const connectedEdges = automataNetwork.getConnectedEdges(
+        nodesSelected[0]
+      );
+      EDGES.remove(connectedEdges);
       automataNetwork.deleteSelected();
       disableEditLabelTextBox();
+      nodeObject.current = {
+        id: "",
+        label: "",
+        x: "",
+        y: ""
+      };
       return;
     }
 
     if (edgesSelected.length) {
       automataNetwork.deleteSelected();
       disableEditLabelTextBox();
+      edgeObject.current = {
+        id: "",
+        from: "",
+        to: "",
+        label: ""
+      };
     }
   };
 


### PR DESCRIPTION
This commit address the issue of when a node was deleted it is successfully removed from the nodes dataset.
However, the connected edges were not getting removed from edges dataset.
and additionally the node and edges object were not getting cleared after deleting.

closes #97 