### PR TITLE
chore() : Add getter/setter for mutable refs object. (#121)

### DIFF
--- a/src/components/workspace/DialogBox.jsx
+++ b/src/components/workspace/DialogBox.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import React, { useRef, useState } from "react";
 import {
   Button,
@@ -18,11 +19,14 @@ const DialogBox = props => {
     close
   } = props;
 
-  const inputRef = useRef(null);
+  const _inputRef = useRef(null);
+  const getInputRef = () => {
+    return _inputRef.current.value;
+  };
   const [inputError, setInputError] = useState(false);
 
   const handleEnterButton = () => {
-    const textInput = inputRef.current.value.trim();
+    const textInput = getInputRef().trim();
     if (textInput === "") {
       setInputError(true);
       return;
@@ -53,7 +57,7 @@ const DialogBox = props => {
           autoComplete="off"
           margin="dense"
           id="label"
-          inputRef={inputRef}
+          inputRef={_inputRef}
           fullWidth
         />
       </DialogContent>

--- a/src/components/workspace/ToolBar.jsx
+++ b/src/components/workspace/ToolBar.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import React, { useRef, useState } from "react";
 import {
   Paper,
@@ -66,8 +67,13 @@ const ToolBar = props => {
      */
     snackbar
   } = props;
+
   const [isExportDialogOpen, setExportDialogOpen] = useState(false);
-  const testInputRef = useRef();
+
+  const _testInputRef = useRef(null);
+  const getTestInputRef = () => {
+    return _testInputRef.current.value;
+  };
 
   /**
    * Handles when clear button is clicked
@@ -156,7 +162,7 @@ const ToolBar = props => {
    * Handles when test button is clicked
    */
   const handleTestOnClick = () => {
-    const testInput = testInputRef.current.value.trim();
+    const testInput = getTestInputRef().trim();
     const data = getNetworkDataSet();
     if (testInput !== "") {
       if (testInput.includes(",")) {
@@ -207,7 +213,7 @@ const ToolBar = props => {
             InputLabelProps={{
               shrink: true
             }}
-            inputRef={testInputRef}
+            inputRef={_testInputRef}
           />
           <Button
             variant="outlined"


### PR DESCRIPTION
Add getter/setter for mutable refs, so don't have to deal with object.current and object.current.value directly.
Make network objects as ref object.
It's not a big deal, but it makes code more readable.


closes #121 