### PR TITLE
fix(Workspace) : Clear node/edge object after add node/edge dialog box is closed. (#123)

### DIFF
--- a/src/components/workspace/Workspace.jsx
+++ b/src/components/workspace/Workspace.jsx
@@ -570,10 +570,10 @@ const Workspace = props => {
    * @param value - Label for the node
    */
   const submitNodeDialogBox = value => {
-    setViewNodeDialog(false);
     if (value === "") return;
     const node = getNodeObject();
     NODES.update({ id: node.id, label: value });
+    setViewNodeDialog(false);
   };
 
   /**
@@ -593,7 +593,6 @@ const Workspace = props => {
    * @param value - Label for the edge
    */
   const submitEdgeDialogBox = value => {
-    setViewEdgeDialog(false);
     if (value === "") return;
     if (value.includes(",")) {
       snackbar("warning", "Edge label cannot contain comma");
@@ -609,8 +608,22 @@ const Workspace = props => {
       edgeLabel = edgeLabelArr.join(", ");
     }
     EDGES.update({ id: edge.id, label: edgeLabel });
+    setViewEdgeDialog(false);
   };
 
+  // clear node object when add node dialog box is closed
+  useEffect(() => {
+    if (!viewNodeDialog) {
+      setNodeObject({});
+    }
+  }, [viewNodeDialog]);
+
+  // clear edge object when add edge dialog box is closed
+  useEffect(() => {
+    if (!viewEdgeDialog) {
+      setEdgeObject({});
+    }
+  }, [viewEdgeDialog]);
   /**
    * Removes all the nodes and edges except the start node
    */


### PR DESCRIPTION
This commit address the issue that a node label is getting updated if an edge label is updated and vice versa.
This also solves one more issue that a new node is getting created if an edge is updated.
As objects were not getting cleared, the update event updates both the node and edge object.


closes #123 