### PR TITLE
fix(Workspace) : Disable edit label textbox after creating an edge (#126)

### DIFF
--- a/src/components/workspace/Workspace.jsx
+++ b/src/components/workspace/Workspace.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
-import React, { useRef, useState, useEffect } from "react";
+import React, { useRef, useState, useEffect, useCallback } from "react";
 import keycharm from "keycharm";
 import { Network } from "vis-network/peer/esm/vis-network";
 import { DataSet } from "vis-data/peer/esm/vis-data";
@@ -194,10 +194,10 @@ const Workspace = props => {
   /**
    * Disable the node/edge label edit box
    */
-  const disableEditLabelTextBox = () => {
+  const disableEditLabelTextBox = useCallback(() => {
     setEditLabelTextBoxRef("");
     setDisableEditLabel(true);
-  };
+  }, []);
 
   /**
    * Handles onBlur event of edit label text box
@@ -622,8 +622,10 @@ const Workspace = props => {
   useEffect(() => {
     if (!viewEdgeDialog) {
       setEdgeObject({});
+      setNodeObject({});
+      disableEditLabelTextBox();
     }
-  }, [viewEdgeDialog]);
+  }, [viewEdgeDialog, disableEditLabelTextBox]);
   /**
    * Removes all the nodes and edges except the start node
    */


### PR DESCRIPTION
This commit address the issue that the edit label textbox was not getting disabled even though the node is out of focus after creating an edge.
First, select the node, it will be on focus then draw an edge from the selected node to another node.
After creating an edge the node will be deselected however the edit label textbox stays enabled.

closes #126 